### PR TITLE
Use protocol relative URL for calls to Google

### DIFF
--- a/src/pages/FindNearbyMap.page
+++ b/src/pages/FindNearbyMap.page
@@ -1,11 +1,11 @@
 <apex:page controller="FindNearbyMap" action="{!init}" sidebar="false"> 
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
+<script type="text/javascript" src="//www.google.com/jsapi"></script>
 <script src="{!URLFOR($Resource.JQ)}" type="text/javascript" ></script>
 <script src="{!URLFOR($Resource.tableDnD)}" type="text/javascript" ></script>
 <script src="{!URLFOR($Resource.jqTable)}" type="text/javascript" ></script>
 <script src="{!URLFOR($Resource.fixedTHeader)}" type="text/javascript" ></script>
-<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.1/jquery-ui.js" type="text/javascript"></script>
-<script src="http://maps.google.com/maps?file=api&v=2&key={!GKey}&sensor=true" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.8.1/jquery-ui.js" type="text/javascript"></script>
+<script src="//maps.google.com/maps?file=api&v=2&key={!GKey}&sensor=true" type="text/javascript"></script>
 <style type='text/css'>
   .Filter{
         background:url("/img/alohaSkin/grid_headerbg.gif") repeat-x scroll 0 bottom #FFFFFF;


### PR DESCRIPTION
Instead of http:// calls to Google for their jsapi, jquery and the maps api call, use either "//" or "https://". Changed to "//" in my example.
